### PR TITLE
Treecode refactor, unmanaged push

### DIFF
--- a/src/opentimelineio/core.zig
+++ b/src/opentimelineio/core.zig
@@ -2378,10 +2378,7 @@ test "TopologicalMap: schema.Track with clip with identity transform topological
 
     // root object code
     {
-        var tc = try treecode.Treecode.init_word(
-            allocator,
-            0b1
-        );
+        var tc = try treecode.Treecode.init(allocator);
         defer tc.deinit(allocator);
         try std.testing.expect(tc.eql(root_code));
         try std.testing.expectEqual(0, tc.code_length());

--- a/src/opentimelineio/core.zig
+++ b/src/opentimelineio/core.zig
@@ -311,7 +311,7 @@ pub const ComposedValueRef = union(enum) {
         allocator: std.mem.Allocator,
         from_space: SpaceLabel,
         to_space: SpaceReference,
-        step: u1,
+        step: treecode.l_or_r,
     ) !topology_m.Topology 
     {
         if (GRAPH_CONSTRUCTION_TRACE_MESSAGES) {
@@ -356,7 +356,7 @@ pub const ComposedValueRef = union(enum) {
                         }
 
                         // no further transformation INTO the child
-                        if (step == 0) {
+                        if (step == .left) {
                             return (
                                 try topology_m.Topology.init_identity_infinite(
                                     allocator

--- a/src/opentimelineio/core.zig
+++ b/src/opentimelineio/core.zig
@@ -2271,7 +2271,7 @@ test "path_code: graph test"
 
         const expect = try treecode.Treecode.init_word(
             allocator,
-            t.expect
+            t.expect,
         );
         defer expect.deinit(allocator);
 

--- a/src/opentimelineio/opentimelineio_highlevel_test.zig
+++ b/src/opentimelineio/opentimelineio_highlevel_test.zig
@@ -102,7 +102,7 @@ test "otio: high level procedural test [clip][   gap    ][clip]"
         allocator,
         tl_ptr
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     // could do individual specific end-to-end projections here
     ///////////////////////////////////////////////////////////////////////////
@@ -142,7 +142,7 @@ test "otio: high level procedural test [clip][   gap    ][clip]"
             try tl_ptr.space(.presentation)
         )
     );
-    defer proj_map.deinit();
+    defer proj_map.deinit(allocator);
 
     const src_discrete_info = (
         try proj_map.source.ref.discrete_info_for_space(.presentation)
@@ -347,7 +347,7 @@ test "libsamplerate w/ high level test -- resample only"
         allocator,
         tl_ptr,
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     const tr_pres_to_cl_media_po = (
         try topo_map.build_projection_operator(
@@ -393,7 +393,7 @@ test "libsamplerate w/ high level test -- resample only"
             true,
         )
     );
-    defer media_samples.deinit();
+    defer media_samples.deinit(allocator);
     try std.testing.expect(media_samples.buffer.len > 0);
 
     // write the input file
@@ -412,7 +412,7 @@ test "libsamplerate w/ high level test -- resample only"
         tl.discrete_info.presentation.?,
         false,
     );
-    defer cl_media_samples_for_tr_pres.deinit();
+    defer cl_media_samples_for_tr_pres.deinit(allocator);
 
     // result should match the timeline's discrete info
     try std.testing.expectEqual(
@@ -501,7 +501,7 @@ test "libsamplerate w/ high level test.retime.interpolating"
         allocator,
         tl_ptr
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     try topo_map.write_dot_graph(
         allocator,
@@ -527,7 +527,7 @@ test "libsamplerate w/ high level test.retime.interpolating"
             true,
         )
     );
-    defer media.deinit();
+    defer media.deinit(allocator);
     try std.testing.expect(media.buffer.len > 0);
 
     // write the input file
@@ -546,7 +546,7 @@ test "libsamplerate w/ high level test.retime.interpolating"
         tl.discrete_info.presentation.?,
         false,
     );
-    defer result.deinit();
+    defer result.deinit(allocator);
 
     // result should match the timeline's discrete info
     try std.testing.expectEqual(
@@ -647,7 +647,7 @@ test "libsamplerate w/ high level test.retime.non_interpolating"
         allocator,
         tl_ptr
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     const tr_pres_to_cl_media_po = (
         try topo_map.build_projection_operator(
@@ -668,7 +668,7 @@ test "libsamplerate w/ high level test.retime.non_interpolating"
             false,
         )
     );
-    defer media.deinit();
+    defer media.deinit(allocator);
     try std.testing.expect(media.buffer.len > 0);
 
     // write the input file
@@ -687,7 +687,7 @@ test "libsamplerate w/ high level test.retime.non_interpolating"
         tl.discrete_info.presentation.?,
         false,
     );
-    defer indices_tr_pres.deinit();
+    defer indices_tr_pres.deinit(allocator);
 
     // result should match the timeline's discrete info
     try std.testing.expectEqual(
@@ -813,7 +813,7 @@ test "libsamplerate w/ high level test.retime.non_interpolating_reverse"
         allocator,
         tl_ptr,
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     // build the projection operator (Track.presentation -> clip.media)
     ///////////////////////////////////////////////////////////////////////////
@@ -966,7 +966,7 @@ test "timeline w/ warp that holds the tenth frame"
         allocator,
         tl_ptr
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     const tr_pres_to_cl_media_po = (
         try topo_map.build_projection_operator(
@@ -1087,7 +1087,7 @@ test "timeline running at 24*1000/1001 with media at 24 showing skew"
         allocator,
         tl_ptr,
     );
-    defer topo_map.deinit();
+    defer topo_map.deinit(allocator);
 
     // Build the projection from Timeline Presentation -> Clip Media
     ///////////////////////////////////////////////////////////////////////////

--- a/src/opentimelineio/opentimelineio_json.zig
+++ b/src/opentimelineio/opentimelineio_json.zig
@@ -425,7 +425,7 @@ test "read_from_file test"
         std.testing.allocator,
         tl_ptr
     );
-    defer map.deinit();
+    defer map.deinit(allocator);
 
     const tl_output_to_clip_media = try map.build_projection_operator(
         std.testing.allocator,

--- a/src/opentimelineio/topological_map.zig
+++ b/src/opentimelineio/topological_map.zig
@@ -87,7 +87,7 @@ pub const TopologicalMap = struct {
         const tree_word = treecode.Treecode{
             .treecode_array = blk: {
                 var output = [_]treecode.TreecodeWord{
-                    treecode.ROOT_TREECODE,
+                    treecode.MARKER,
                 };
                 break :blk &output;
             },
@@ -306,7 +306,7 @@ pub const TopologicalMap = struct {
                 .space = root_space,
                 .code = try treecode.Treecode.init_word(
                     allocator,
-                    treecode.ROOT_TREECODE,
+                    treecode.MARKER,
                 )
             }
         );
@@ -596,7 +596,7 @@ pub fn build_topological_map(
     // 1a
     const start_code = try treecode.Treecode.init_word(
         allocator,
-        treecode.ROOT_TREECODE,
+        treecode.MARKER,
     );
 
     // root node

--- a/src/opentimelineio/topological_map.zig
+++ b/src/opentimelineio/topological_map.zig
@@ -304,11 +304,8 @@ pub const TopologicalMap = struct {
         try stack.append(
             .{
                 .space = root_space,
-                .code = try treecode.Treecode.init_word(
-                    allocator,
-                    treecode.MARKER,
-                )
-            }
+                .code = try treecode.Treecode.init(allocator),
+            },
         );
 
         var maybe_current = stack.pop();
@@ -594,25 +591,22 @@ pub fn build_topological_map(
     }
 
     // 1a
-    const start_code = try treecode.Treecode.init_word(
-        allocator,
-        treecode.MARKER,
-    );
+    const start_code = try treecode.Treecode.init(allocator);
 
     // root node
     try stack.append(
         allocator,
         .{
             .object = root_item,
-            .path_code = start_code
-        }
+            .path_code = start_code,
+        },
     );
 
     if (GRAPH_CONSTRUCTION_TRACE_MESSAGES) {
         opentime.dbg_print(
             @src(),
             "\nstarting graph...\n",
-            .{}
+            .{},
         );
     }
 

--- a/src/treecode/treecode.zig
+++ b/src/treecode/treecode.zig
@@ -69,13 +69,11 @@ pub const Treecode = struct {
         input: TreecodeWord,
     ) !Treecode 
     {
-        const treecode_array = try allocator.dupe(
-            TreecodeWord,
-            &.{ input },
-        );
-
         return .{
-            .treecode_array = treecode_array,
+            .treecode_array = try allocator.dupe(
+                TreecodeWord,
+                &.{ input },
+            ),
         };
     }
 

--- a/src/treecode/treecode.zig
+++ b/src/treecode/treecode.zig
@@ -77,12 +77,11 @@ pub const Treecode = struct {
         input: TreecodeWord,
     ) !Treecode 
     {
-        var treecode_array = try allocator.alloc(
+        const treecode_array = try allocator.dupe(
             TreecodeWord,
-            1,
+            &.{ input },
         );
 
-        treecode_array[0] = input;
         return .{
             .sz = 1,
             .treecode_array = treecode_array 


### PR DESCRIPTION
* Converts ProjectionOperator and a few other types (including `Treecode`) to be unmanaged
* Refactors and rewrites documentation for Treecode:
  * removes `init_fill_count`
  * `ROOT_TREECODE` -> `MARKER`
  * adds init() to replace `init_word(allocator, MARKER)`
  * replaces references to `0b1` for `MARKER`
  * `is_superset_of` -> `is_prefix_of`
  * adds some additional tests
  * uses `const allocator = std.testing.allocator;` in tests
  * fleshes out a LOT of the documentation, tries to clarify the memory layout and how to interpret a treecode
  * removes the `sz` field as well, redundant to `treecode_array.len`
  * adds an `l_or_r: enum(u1)` for representing left/right path steps